### PR TITLE
Fix sequence checking logic

### DIFF
--- a/src/main/java/com/ceridwen/circulation/SIP/transport/Connection.java
+++ b/src/main/java/com/ceridwen/circulation/SIP/transport/Connection.java
@@ -124,12 +124,11 @@ public abstract class Connection {
     }
 
     private char getNextSequence() {
-        char ret = this.sequence;
         this.sequence++;
         if (this.sequence > '9') {
             this.sequence = '0';
         }
-        return ret;
+        return sequence;
     }
     
     protected String strim(String input) {
@@ -213,7 +212,7 @@ public abstract class Connection {
                 retry = false;
                 try {
                     if (this.getAddSequenceAndChecksum()) {
-                        request = msg.encode(Character.valueOf(this.getNextSequence()));
+                        request = msg.encode(this.getNextSequence());
                     } else {
                         request = msg.encode(null);
                     }

--- a/src/main/java/com/ceridwen/circulation/SIP/transport/SocketConnection.java
+++ b/src/main/java/com/ceridwen/circulation/SIP/transport/SocketConnection.java
@@ -32,7 +32,7 @@ import com.ceridwen.circulation.SIP.exceptions.ConnectionFailure;
 import com.ceridwen.circulation.SIP.exceptions.RetriesExceeded;
 import com.ceridwen.circulation.SIP.messages.Message;
 
-public class SocketConnection extends Connection {
+public class SocketConnection extends Connection implements AutoCloseable {
     private static Log log = LogFactory.getLog(SocketConnection.class);
 
     private Socket socket;
@@ -92,7 +92,7 @@ public class SocketConnection extends Connection {
 
     @Override
     protected String internalWaitfor(String match) throws ConnectionFailure {
-        StringBuffer message = new StringBuffer();
+        StringBuilder message = new StringBuilder();
         char buffer[] = new char[2048];
         int len;
         long giveup = System.currentTimeMillis() + this.getIdleTimeout();
@@ -101,7 +101,7 @@ public class SocketConnection extends Connection {
             do {
                 len = this.in.read(buffer);
                 message.append(new String(buffer, 0, len));
-            } while ((message.toString()).lastIndexOf(match) < 0 && System.currentTimeMillis() < giveup);
+            } while (message.lastIndexOf(match) < 0 && System.currentTimeMillis() < giveup);
         } catch (Exception ex) {
             throw new ConnectionFailure(ex);
         }
@@ -110,5 +110,12 @@ public class SocketConnection extends Connection {
         int cutoff = msg.lastIndexOf(match);
         String ret = msg.substring(0, cutoff);
         return ret;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.socket.close();
+        this.in.close();
+        this.out.close();
     }
 }


### PR DESCRIPTION
Issue:
- Sequence checking logic is currently broken.
- When getNextSequence() is called, it returns ascii character equivalent to this.sequence-1.
- This sequence character is used in the request sent to library ACS.
- When StrictSequenceChecking is enabled, response sequence number character should be same as 
   the request sequence number character.
- Current implementation checks the response sequence character against the incremented 
   sequence number character (to be used for next request) and results in exception.

SIP2 Error Handling using Sequence Number:
- the sequence number field’s value of the response should  match the sequence number value from the message being responded to.

Solution:
- Increment and return the incremented sequence number character.
- Now equality holds for  sequence number characters of request and subsequent response.

Bonus: SocketConnection.java
- use StringBuilder; recommended for single threaded operations.
- do not convert string buffer to String every time to check the lastIndexOf, use the method provided 
   by StringBuffer/StringBuilder class.
- Make SocketConnection autoclosable, so that it could be closed automatically when used with try-with-resource block.